### PR TITLE
feat: implement CRUD operations for search profiles with authorization

### DIFF
--- a/backend/src/controllers/searchProfileController.js
+++ b/backend/src/controllers/searchProfileController.js
@@ -85,3 +85,142 @@ exports.createSearchProfile = async (req, res) => {
     res.status(500).json({ error: 'Error interno del servidor' });
   }
 };
+
+// Actualización completa (PUT)
+exports.updateSearchProfile = async (req, res) => {
+  const { id } = req.params;
+  const updateData = req.body;
+  try {
+    // LOGS PARA DEPURAR
+    console.log('req.user.id:', req.user.id);
+    console.log('Perfil de búsqueda id:', id);
+
+    const { data: profile, error: fetchError } = await supabase
+      .from('tenant_search_profiles')
+      .select('tenant_id')
+      .eq('id', id)
+      .single();
+
+    console.log('Perfil encontrado:', profile);
+
+    if (fetchError || !profile || profile.tenant_id !== req.user.id) {
+      return res.status(403).json({ error: 'No tienes permiso para modificar este perfil.' });
+    }
+
+    const { error } = await supabase
+      .from('tenant_search_profiles')
+      .update(updateData)
+      .eq('id', id);
+    if (error) return res.status(400).json({ error: error.message });
+    res.json({ message: 'Perfil de búsqueda actualizado correctamente.' });
+  } catch (err) {
+    res.status(500).json({ error: 'Error interno del servidor.' });
+  }
+}
+
+// Actualización parcial (PATCH)
+exports.partialUpdateSearchProfile = async (req, res) => {
+  const { id } = req.params;
+  const updateData = req.body;
+  try {
+    // Verificar propiedad del recurso
+    const { data: profile, error: fetchError } = await supabase
+      .from('tenant_search_profiles')
+      .select('tenant_id')
+      .eq('id', id)
+      .single();
+
+    if (fetchError || !profile || profile.tenant_id !== req.user.id) {
+      return res.status(403).json({ error: 'No tienes permiso para modificar este perfil.' });
+    }
+
+    const { error } = await supabase
+      .from('tenant_search_profiles')
+      .update(updateData)
+      .eq('id', id);
+    if (error) return res.status(400).json({ error: error.message });
+    res.json({ message: 'Perfil de búsqueda actualizado parcialmente.' });
+  } catch (err) {
+    res.status(500).json({ error: 'Error interno del servidor.' });
+  }
+};
+
+// Eliminar perfil de búsqueda
+exports.deleteSearchProfile = async (req, res) => {
+  const { id } = req.params;
+  try {
+    // Verificar propiedad del recurso
+    const { data: profile, error: fetchError } = await supabase
+      .from('tenant_search_profiles')
+      .select('tenant_id')
+      .eq('id', id)
+      .single();
+
+    if (fetchError || !profile || profile.tenant_id !== req.user.id) {
+      return res.status(403).json({ error: 'No tienes permiso para eliminar este perfil.' });
+    }
+
+    const { error } = await supabase
+      .from('tenant_search_profiles')
+      .delete()
+      .eq('id', id);
+    if (error) return res.status(400).json({ error: error.message });
+    res.json({ message: 'Perfil de búsqueda eliminado correctamente.' });
+  } catch (err) {
+    res.status(500).json({ error: 'Error interno del servidor.' });
+  }
+};
+
+// Obtener todos los perfiles de búsqueda del usuario
+exports.getMySearchProfiles = async (req, res) => {
+  try {
+    const { data, error } = await supabase
+      .from('tenant_search_profiles')
+      .select(`
+        id,
+        property_types,
+        status,
+        budget_min,
+        budget_max,
+        city,
+        neighborhood,
+        created_at,
+        rooms_min,
+        rooms_max
+      `)
+      .eq('tenant_id', req.user.id)
+      .order('created_at', { ascending: false });
+
+    if (error) return res.status(400).json({ error: error.message });
+
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ error: 'Error interno del servidor.' });
+  }
+};
+
+// Obtener detalle de un perfil de búsqueda específico
+
+exports.getSearchProfileDetail = async (req, res) => {
+  const { id } = req.params;
+  try {
+    // Buscar el perfil y verificar que pertenezca al usuario autenticado
+    const { data: profile, error } = await supabase
+      .from('tenant_search_profiles')
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (error || !profile) {
+      return res.status(404).json({ error: 'Perfil de búsqueda no encontrado.' });
+    }
+
+    if (profile.tenant_id !== req.user.id) {
+      return res.status(403).json({ error: 'No tienes permiso para ver este perfil.' });
+    }
+
+    res.json(profile);
+  } catch (err) {
+    res.status(500).json({ error: 'Error interno del servidor.' });
+  }
+};

--- a/backend/src/routes/searchProfileRoutes.js
+++ b/backend/src/routes/searchProfileRoutes.js
@@ -3,6 +3,20 @@ const express = require('express');
 const router = express.Router();
 const searchProfileController = require('../controllers/searchProfileController');
 
-router.post('/search-profile', authenticateToken, authorizeTenant, searchProfileController.createSearchProfile);
+// Crear un nuevo perfil de búsqueda
+router.post('/', authenticateToken, authorizeTenant, searchProfileController.createSearchProfile);
+
+// Editar perfil de búsqueda (PUT para reemplazo completo, PATCH para parcial)
+router.put('/:id', authenticateToken, authorizeTenant, searchProfileController.updateSearchProfile);
+router.patch('/:id', authenticateToken, authorizeTenant, searchProfileController.partialUpdateSearchProfile);
+
+// Eliminar perfil de búsqueda
+router.delete('/:id', authenticateToken, authorizeTenant, searchProfileController.deleteSearchProfile);
+
+// Obtener todos los perfiles de búsqueda
+router.get('/', authenticateToken, authorizeTenant, searchProfileController.getMySearchProfiles);
+
+// Obtener detalle de un perfil de búsqueda específico
+router.get('/:id', authenticateToken, authorizeTenant, searchProfileController.getSearchProfileDetail);
 
 module.exports = router;


### PR DESCRIPTION
This pull request adds full CRUD (Create, Read, Update, Delete) functionality for tenant search profiles in the backend. It introduces new controller methods and corresponding RESTful routes, allowing authenticated tenants to manage their own search profiles securely.

**Backend controller enhancements:**

* Added `updateSearchProfile` (PUT) and `partialUpdateSearchProfile` (PATCH) methods to allow tenants to update their search profiles, with ownership checks to ensure security.
* Implemented `deleteSearchProfile` to allow tenants to delete their own search profiles, with proper authorization.
* Added `getMySearchProfiles` to fetch all search profiles belonging to the authenticated tenant, and `getSearchProfileDetail` to fetch details of a specific profile, both with ownership validation.

**Route updates:**

* Updated `searchProfileRoutes.js` to provide RESTful endpoints for creating, updating (PUT/PATCH), deleting, listing, and retrieving details of search profiles, all protected by authentication and tenant authorization middleware.

<img width="647" height="647" alt="image" src="https://github.com/user-attachments/assets/1af50e09-789e-4ed9-af34-925dc4386e2a" />

<img width="667" height="615" alt="image" src="https://github.com/user-attachments/assets/d580a299-3e1e-4c17-a960-d5cfad84c063" />

<img width="619" height="486" alt="image" src="https://github.com/user-attachments/assets/721c4cca-cba8-4553-925f-2ffb760c4381" />

<img width="653" height="834" alt="image" src="https://github.com/user-attachments/assets/1e1558e4-25d8-4fcf-b44f-25ab4fda1b59" />

<img width="668" height="831" alt="image" src="https://github.com/user-attachments/assets/d5b16d6f-77fc-4d34-88cb-e7f5cf56f879" />
